### PR TITLE
Removed most refs. Mix & match models with different extensions.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+import { GLTFLoaderPlugin } from 'xeokit-sdk/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin';
+import { XKTLoaderPlugin } from 'xeokit-sdk/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin';
+
 export const pickEntity = (viewer, eventToPickOn, setPickedEntityID) => {
   let lastEntity = null;
   let lastColorize = null;
@@ -43,3 +46,15 @@ export const setCamera = (viewer, cameraSettings) => {
     }
   });
 };
+
+const loaders = {
+  gltf: GLTFLoaderPlugin,
+  xkt: XKTLoaderPlugin,
+};
+
+const getExtension = (fileName) => {
+  const extension = fileName.match(/\.(\w+)$/);
+  return extension && extension[1].toLowerCase();
+};
+
+export const getLoaderByExtension = fileName => loaders[getExtension(fileName)];


### PR DESCRIPTION
As per our previous discussions and brainstorming sessions, I'm sending a PR with the following improvements and changes:

- removed most refs; the reason being that the xeokit sdk actually stores most everything needed on the viewer instance
- added the ability to load models with different extensions into the same viewer
- cleaned up some of the examples

Let know what you think.

Best,

tothatt